### PR TITLE
fix: remove constraints for ios12.2,ipad pro 3rd

### DIFF
--- a/front/src/features/barcodeLoader/components/Video.tsx
+++ b/front/src/features/barcodeLoader/components/Video.tsx
@@ -12,10 +12,6 @@ export const Video: React.FC = ({}) => {
           name: 'Live',
           type: 'LiveStream',
           target: document.querySelector('#video'),
-          constraints: {
-            width: window.innerWidth - 40, // todo: calculate size from dom
-            height: window.innerHeight - 200,
-          },
         } as QuaggaJSConfigObject['inputStream'],
         numOfWorkers: 1,
         locate: true,


### PR DESCRIPTION
ipad pro 3rd gen has crashed `getUserMedia` with witch,height property