### PR TITLE
build(front): testを有効にした

### DIFF
--- a/packages/front/.babelrc
+++ b/packages/front/.babelrc
@@ -1,0 +1,7 @@
+{
+  "env": {
+    "test": {
+      "plugins": ["require-context-hook"]
+    }
+  }
+}

--- a/packages/front/package.json
+++ b/packages/front/package.json
@@ -7,6 +7,7 @@
   "dependencies": {
     "@material/react-linear-progress": "^0.15.0",
     "@types/history": "^4.7.2",
+    "@types/jest": "^24.0.17",
     "@types/papaparse": "^5.0.1",
     "@types/react": "16.9.1",
     "@types/react-dom": "16.8.5",
@@ -44,7 +45,7 @@
     "start": "react-app-rewired start",
     "build": "REACT_APP_BRANCH=$(git rev-parse --abbrev-ref HEAD) REACT_APP_VERSION=$(git rev-parse --short=10 HEAD) react-app-rewired build",
     "build:prod": "REACT_APP_TARGET=prod yarn run build",
-    "test": "echo \"no test \" # react-app-rewired test --env=jsdom # fixme: compilerOptions.baseUrl must not be set (absolute imports are not supported (yet))",
+    "test": "react-app-rewired test",
     "eject": "react-app-rewired eject",
     "deploy": "firebase deploy --only hosting:bibliotheca-site",
     "g": "plop feature"
@@ -73,6 +74,7 @@
     "arrowParens": "avoid"
   },
   "devDependencies": {
+    "babel-plugin-require-context-hook": "^1.0.0",
     "date-fns": "^1.30.1",
     "firebase": "^6.3.5",
     "plop": "^2.4.0",

--- a/packages/front/src/bibliotheca/__mocks__/routes.ts
+++ b/packages/front/src/bibliotheca/__mocks__/routes.ts
@@ -1,0 +1,14 @@
+import { createMemoryNavigation } from 'navi';
+
+const actualRoutes = jest.requireActual('bibliotheca/routes');
+
+const { resolveRoutes } = actualRoutes;
+
+const mock = {
+  ...actualRoutes,
+  getNavigation: () => createMemoryNavigation({ routes: resolveRoutes(), url: '/' }),
+};
+
+export {};
+
+module.exports = mock;

--- a/packages/front/src/bibliotheca/components/App.test.tsx
+++ b/packages/front/src/bibliotheca/components/App.test.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { App } from './App';
+
+import { DefaultTypelessProvider } from 'typeless';
+
+jest.mock('bibliotheca/routes');
+
+it('renders without crashing', () => {
+  const div = document.createElement('div');
+  ReactDOM.render(
+    <DefaultTypelessProvider>
+      <App />
+    </DefaultTypelessProvider>,
+    div,
+  );
+  ReactDOM.unmountComponentAtNode(div);
+});

--- a/packages/front/src/bibliotheca/components/App.tsx
+++ b/packages/front/src/bibliotheca/components/App.tsx
@@ -2,7 +2,7 @@ import { useBookModule } from 'bibliotheca/features/book/module';
 import { useGlobalModule } from 'bibliotheca/features/global/module';
 import { useNotificationModule } from 'bibliotheca/features/notification/module';
 import { useRouterModule } from 'bibliotheca/features/router/module';
-import { navigation } from 'bibliotheca/routes';
+import { getNavigation } from 'bibliotheca/routes';
 import { NotFoundError } from 'navi';
 import React, { Suspense } from 'react';
 import { NotFoundBoundary, Router, View } from 'react-navi';
@@ -27,7 +27,7 @@ export const App = () => {
   useNotificationModule();
 
   return (
-    <Router navigation={navigation}>
+    <Router navigation={getNavigation()}>
       <NotFoundBoundary render={NotFound}>
         <Suspense fallback={<FullScreenSpinner />}>
           <View />

--- a/packages/front/src/bibliotheca/features/router/module.ts
+++ b/packages/front/src/bibliotheca/features/router/module.ts
@@ -1,4 +1,4 @@
-import { navigation } from 'bibliotheca/routes';
+import { getNavigation } from 'bibliotheca/routes';
 import { Route } from 'navi';
 import * as Rx from 'typeless/rx';
 import { handle, RouterActions, RouterLocation, RouterState } from './interface';
@@ -25,14 +25,14 @@ export const epic = handle
       new Rx.Observable(subscriber => {
         const emitter = (location: RouterLocation) =>
           subscriber.next(RouterActions.locationChange(location));
-        emitLocationChageIfNeeded(navigation.getCurrentValue(), emitter);
-        return navigation.subscribe(route => {
+        emitLocationChageIfNeeded(getNavigation().getCurrentValue(), emitter);
+        return getNavigation().subscribe(route => {
           emitLocationChageIfNeeded(route, emitter);
         });
       }),
   )
   .on(RouterActions.navigate, ({ url }) => {
-    return Rx.fromPromise(navigation.navigate(url)).pipe(
+    return Rx.fromPromise(getNavigation().navigate(url)).pipe(
       Rx.map(route => RouterActions.locationChange(toRouterLocation(route))),
     );
   });

--- a/packages/front/src/bibliotheca/routes.ts
+++ b/packages/front/src/bibliotheca/routes.ts
@@ -11,7 +11,7 @@ const staticRoute: Record<string, Matcher<any>> = {
   '/': redirect(getDefaultRoute()),
 };
 
-const resolveRoutes = () => {
+export const resolveRoutes = () => {
   const req = require.context('./features', true, /interface.tsx?$/);
   const targetModules = req.keys().map(key => req(key));
   const matcherEntry = targetModules.reduce((acc, module) => {
@@ -27,8 +27,7 @@ const resolveRoutes = () => {
   return mount({ ...matcherEntry, ...staticRoute });
 };
 
-const routes = resolveRoutes();
-export const navigation = createBrowserNavigation({ routes });
+export const getNavigation = () => createBrowserNavigation({ routes: resolveRoutes() });
 
 export function withAuthentication(matcher: Matcher<any, any>) {
   return map(request => {

--- a/packages/front/src/bibliotheca/routes.ts
+++ b/packages/front/src/bibliotheca/routes.ts
@@ -1,5 +1,5 @@
 import { RouteEntry } from 'bibliotheca/types';
-import { createBrowserNavigation, map, Matcher, mount, redirect } from 'navi';
+import { createBrowserNavigation, map, Matcher, mount, redirect, Navigation } from 'navi';
 import { getGlobalState } from './features/global/interface';
 import {
   decideRedirectUrlFromRequest,
@@ -27,7 +27,14 @@ export const resolveRoutes = () => {
   return mount({ ...matcherEntry, ...staticRoute });
 };
 
-export const getNavigation = () => createBrowserNavigation({ routes: resolveRoutes() });
+let navigation: Navigation;
+export const getNavigation = () => {
+  if (navigation) {
+    return navigation;
+  }
+  navigation = createBrowserNavigation({ routes: resolveRoutes() });
+  return navigation;
+};
 
 export function withAuthentication(matcher: Matcher<any, any>) {
   return map(request => {

--- a/packages/front/src/bibliotheca/services/firebase.ts
+++ b/packages/front/src/bibliotheca/services/firebase.ts
@@ -3,6 +3,8 @@ import 'firebase/auth';
 import 'firebase/firestore';
 import 'firebase/performance';
 
+export { _firebase as firebase };
+
 interface FirebaseConfig {
   apikey: string;
   authdomain: string;
@@ -13,9 +15,11 @@ interface FirebaseConfig {
   appid?: string;
 }
 
-const config: FirebaseConfig = JSON.parse(process.env.REACT_APP_FIREBASE_CONFIG as any);
+try {
+  const config: FirebaseConfig = JSON.parse(process.env.REACT_APP_FIREBASE_CONFIG as any);
+  _firebase.initializeApp(config);
+} catch {
+  alert('firebaseの初期化に失敗しました。管理者まで連絡してください');
+}
 
-_firebase.initializeApp(config);
-
-export const firebase = _firebase;
 export const perf = _firebase.performance();

--- a/packages/front/src/setupTests.js
+++ b/packages/front/src/setupTests.js
@@ -1,0 +1,8 @@
+const registerRequireContextHook = require('babel-plugin-require-context-hook/register');
+
+registerRequireContextHook();
+
+const noop = () => {};
+Object.defineProperty(window, 'scroll', { value: noop, writable: true });
+
+export {}

--- a/packages/front/tsconfig.json
+++ b/packages/front/tsconfig.json
@@ -12,8 +12,7 @@
     "esModuleInterop": true,
     "allowJs": false,
     "skipLibCheck": true,
-    "typeRoots": ["node_modules/@types"],
-    "types": ["webpack-env"],
+    "types": ["webpack-env", "jest"],
     "isolatedModules": true
   },
   "include": ["src"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -2497,6 +2497,18 @@
     "@types/istanbul-lib-coverage" "*"
     "@types/istanbul-lib-report" "*"
 
+"@types/jest-diff@*":
+  version "20.0.1"
+  resolved "https://registry.yarnpkg.com/@types/jest-diff/-/jest-diff-20.0.1.tgz#35cc15b9c4f30a18ef21852e255fdb02f6d59b89"
+  integrity sha512-yALhelO3i0hqZwhjtcr6dYyaLoCHbAMshwtj6cGxTvHZAKXHsYGdff6E8EPw3xLKY0ELUTQ69Q1rQiJENnccMA==
+
+"@types/jest@^24.0.17":
+  version "24.0.17"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-24.0.17.tgz#b66ea026efb746eb5db1356ee28518aaff7af416"
+  integrity sha512-1cy3xkOAfSYn78dsBWy4M3h/QF/HeWPchNFDjysVtp3GHeTdSmtluNnELfCmfNRRHo0OWEcpf+NsEJQvwQfdqQ==
+  dependencies:
+    "@types/jest-diff" "*"
+
 "@types/json-schema@^7.0.3":
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.3.tgz#bdfd69d61e464dcc81b25159c270d75a73c1a636"
@@ -3477,6 +3489,11 @@ babel-plugin-named-asset-import@^0.3.3:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/babel-plugin-named-asset-import/-/babel-plugin-named-asset-import-0.3.3.tgz#9ba2f3ac4dc78b042651654f07e847adfe50667c"
   integrity sha512-1XDRysF4894BUdMChT+2HHbtJYiO7zx5Be7U6bT8dISy7OdyETMGIAQBMPQCsY1YRf0xcubwnKKaDr5bk15JTA==
+
+babel-plugin-require-context-hook@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-require-context-hook/-/babel-plugin-require-context-hook-1.0.0.tgz#3f0e7cce87c338f53639b948632fd4e73834632d"
+  integrity sha512-EMZD1563QUqLhzrqcThk759RhuNVX/ZJdrtGK6drwzgvnR+ARjWyXIHPbu+tUNaMGtPz/gQeAM2M6VUw2UiUeA==
 
 "babel-plugin-styled-components@>= 1":
   version "1.10.6"


### PR DESCRIPTION
本当は require.context をやめたかったが、コード生成の際に自動で import を追加したりそれを適切に routes に組み上げる部分が一筋縄では行かなそうだったので一旦これで。