### PR TITLE
fix: crashed when logout

### DIFF
--- a/packages/bibliotheca-src.code-workspace
+++ b/packages/bibliotheca-src.code-workspace
@@ -10,5 +10,7 @@
 		"path": "seed"
 	}
 ],
-  "settings": {}
+  "settings": {
+    "editor.formatOnSave": true
+  }
 }

--- a/packages/front/.blueprints/feature/{{name}}/routes.tsx
+++ b/packages/front/.blueprints/feature/{{name}}/routes.tsx
@@ -1,10 +1,9 @@
 import { withAuthentication } from 'bibliotheca/routes';
-import { AppContext } from 'bibliotheca/types';
 import { mount, route } from 'navi';
 import React from 'react';
 import { {{pascalCase name}}Module } from './module';
 
-export default mount<AppContext>({
+export default mount({
   '/': withAuthentication(
     route({
       title: '{{pascalCase name}}',

--- a/packages/front/.blueprints/feature/{{name}}/routes.tsx
+++ b/packages/front/.blueprints/feature/{{name}}/routes.tsx
@@ -2,12 +2,13 @@ import { withAuthentication } from 'bibliotheca/routes';
 import { mount, route } from 'navi';
 import React from 'react';
 import { {{pascalCase name}}Module } from './module';
+import { Dashboard } from 'bibliotheca/components/Dashboard';
 
 export default mount({
   '/': withAuthentication(
     route({
       title: '{{pascalCase name}}',
-      view: <{{pascalCase name }}Module />,
+      view: <Dashboard><{{pascalCase name }}Module /></Dashboard>,
     }),
   ),
 });

--- a/packages/front/src/bibliotheca/components/App.tsx
+++ b/packages/front/src/bibliotheca/components/App.tsx
@@ -3,13 +3,10 @@ import { useGlobalModule } from 'bibliotheca/features/global/module';
 import { useNotificationModule } from 'bibliotheca/features/notification/module';
 import { useRouterModule } from 'bibliotheca/features/router/module';
 import { navigation } from 'bibliotheca/routes';
-import { Grommet } from 'grommet';
 import { NotFoundError } from 'navi';
 import React, { Suspense } from 'react';
 import { NotFoundBoundary, Router, View } from 'react-navi';
-import { Dashboard } from './Dashboard';
 import { FullScreenSpinner } from './FullScreenSpinner';
-import { getGlobalState } from 'bibliotheca/features/global/interface';
 
 const setGlobalValue = () => {
   if (process.env.NODE_ENV === 'production') {
@@ -21,20 +18,6 @@ const setGlobalValue = () => {
 };
 setGlobalValue();
 
-interface LayoutProps {
-  children: React.ReactElement;
-}
-export const Layout: React.SFC<LayoutProps> = ({ children }: LayoutProps) => {
-  const { user } = getGlobalState.useState();
-
-  return !user ? (
-    children
-  ) : (
-    <Grommet plain>
-      <Dashboard>{children}</Dashboard>
-    </Grommet>
-  );
-};
 const NotFound = (_error: NotFoundError) => <>not found :cry:</>;
 
 export const App = () => {
@@ -45,13 +28,11 @@ export const App = () => {
 
   return (
     <Router navigation={navigation}>
-      <Layout>
-        <NotFoundBoundary render={NotFound}>
-          <Suspense fallback={<FullScreenSpinner />}>
-            <View />
-          </Suspense>
-        </NotFoundBoundary>
-      </Layout>
+      <NotFoundBoundary render={NotFound}>
+        <Suspense fallback={<FullScreenSpinner />}>
+          <View />
+        </Suspense>
+      </NotFoundBoundary>
     </Router>
   );
 };

--- a/packages/front/src/bibliotheca/components/Dashboard.tsx
+++ b/packages/front/src/bibliotheca/components/Dashboard.tsx
@@ -1,7 +1,7 @@
 import { Progress } from 'bibliotheca/features/global/components/Progress';
 import { getGlobalState, GlobalActions } from 'bibliotheca/features/global/interface';
 import { RouterActions } from 'bibliotheca/features/router/interface';
-import { Box, ButtonProps, Heading, Menu, ResponsiveContext, Tab, Tabs } from 'grommet';
+import { Box, ButtonProps, Heading, Menu, ResponsiveContext, Tab, Tabs, Grommet } from 'grommet';
 import {
   Add as AddIcon,
   Configure as ManagementIcon,
@@ -97,7 +97,7 @@ export const Dashboard = (props: DashboardProps) => {
   return (
     <ResponsiveContext.Consumer>
       {size => (
-        <>
+        <Grommet plain>
           <Progress />
           <AppBar>
             <Heading level="3" margin="none">
@@ -119,7 +119,7 @@ export const Dashboard = (props: DashboardProps) => {
             </Box>
           </AppBar>
           <Main>{children}</Main>
-        </>
+        </Grommet>
       )}
     </ResponsiveContext.Consumer>
   );

--- a/packages/front/src/bibliotheca/components/Dashboard.tsx
+++ b/packages/front/src/bibliotheca/components/Dashboard.tsx
@@ -43,7 +43,8 @@ export const Dashboard = (props: DashboardProps) => {
   const { logout } = useActions(GlobalActions);
   const { navigate } = useActions(RouterActions);
   const route = useCurrentRoute();
-  const userId = getGlobalState.useState().user!.email;
+  const { user } = getGlobalState.useState();
+  const userId = user == null ? '' : user.email;
 
   const links = [
     { link: '/books', title: '書籍一覧' },

--- a/packages/front/src/bibliotheca/features/book/routes.tsx
+++ b/packages/front/src/bibliotheca/features/book/routes.tsx
@@ -1,14 +1,13 @@
 import { mount, route } from 'navi';
 import React from 'react';
 import { withAuthentication } from 'bibliotheca/routes';
-import { AppContext } from 'bibliotheca/types';
 import { BookListModule } from './bookList/module';
 import { BookDetailModule } from './detail/module';
 import { BookRegisterModule } from './register/module';
 
 // --- Routing ---
 export default withAuthentication(
-  mount<AppContext>({
+  mount({
     '/': route({
       title: '書籍一覧 - Bibliotheca',
       view: <BookListModule />,

--- a/packages/front/src/bibliotheca/features/book/routes.tsx
+++ b/packages/front/src/bibliotheca/features/book/routes.tsx
@@ -4,21 +4,34 @@ import { withAuthentication } from 'bibliotheca/routes';
 import { BookListModule } from './bookList/module';
 import { BookDetailModule } from './detail/module';
 import { BookRegisterModule } from './register/module';
+import { Dashboard } from 'bibliotheca/components/Dashboard';
 
 // --- Routing ---
 export default withAuthentication(
   mount({
     '/': route({
       title: '書籍一覧 - Bibliotheca',
-      view: <BookListModule />,
+      view: (
+        <Dashboard>
+          <BookListModule />
+        </Dashboard>
+      ),
     }),
     '/:bookId': route({
       title: '書籍詳細 - Bibliotheca',
-      view: <BookDetailModule />,
+      view: (
+        <Dashboard>
+          <BookDetailModule />
+        </Dashboard>
+      ),
     }),
     '/register': route({
       title: '書籍登録 - Bibliotheca',
-      view: <BookRegisterModule />,
+      view: (
+        <Dashboard>
+          <BookRegisterModule />
+        </Dashboard>
+      ),
     }),
   }),
 );

--- a/packages/front/src/bibliotheca/features/borrowOrReturn/routes.tsx
+++ b/packages/front/src/bibliotheca/features/borrowOrReturn/routes.tsx
@@ -1,11 +1,10 @@
+import { withAuthentication } from 'bibliotheca/routes';
 import { mount, route } from 'navi';
 import React from 'react';
-import { withAuthentication } from 'bibliotheca/routes';
-import { AppContext } from 'bibliotheca/types';
 import { BorrowOrReturnModule } from './module';
 
 // --- Routing ---
-export default mount<AppContext>({
+export default mount({
   '/': withAuthentication(
     route({
       title: '貸出/返却 - Bibliotheca',

--- a/packages/front/src/bibliotheca/features/borrowOrReturn/routes.tsx
+++ b/packages/front/src/bibliotheca/features/borrowOrReturn/routes.tsx
@@ -2,13 +2,18 @@ import { withAuthentication } from 'bibliotheca/routes';
 import { mount, route } from 'navi';
 import React from 'react';
 import { BorrowOrReturnModule } from './module';
+import { Dashboard } from 'bibliotheca/components/Dashboard';
 
 // --- Routing ---
 export default mount({
   '/': withAuthentication(
     route({
       title: '貸出/返却 - Bibliotheca',
-      view: <BorrowOrReturnModule />,
+      view: (
+        <Dashboard>
+          <BorrowOrReturnModule />
+        </Dashboard>
+      ),
     }),
   ),
 });

--- a/packages/front/src/bibliotheca/features/global/module.tsx
+++ b/packages/front/src/bibliotheca/features/global/module.tsx
@@ -21,7 +21,10 @@ export const epic = handle
   })
   .on(GlobalActions.logout, () => {
     if (subscribe) subscribe();
-    return Rx.from(authService.logout()).pipe(Rx.ignoreElements());
+    return Rx.concatObs(
+      Rx.from(authService.logout()).pipe(Rx.ignoreElements()),
+      Rx.of(RouterActions.navigate('/login')),
+    );
   });
 
 // --- Reducer ---
@@ -36,6 +39,9 @@ export const reducer = handle
   .on(GlobalActions.loggedIn, (state, { user }) => {
     state.isLoaded = true;
     state.user = user == null ? null : { firebaseAuth: user, email: user.email! };
+  })
+  .on(GlobalActions.logout, state => {
+    state.user = null;
   })
   .on(GlobalActions.progressShow, state => {
     state.progress = true;

--- a/packages/front/src/bibliotheca/features/global/module.tsx
+++ b/packages/front/src/bibliotheca/features/global/module.tsx
@@ -1,15 +1,28 @@
 import { authService } from 'bibliotheca/services/ServiceContainer';
 import * as Rx from 'typeless/rx';
-import { RouterActions } from '../router/interface';
 import { GlobalActions, GlobalState, handle } from './interface';
+import { RouterActions } from '../router/interface';
+import { getDefaultRoute } from '../router/helper';
 
 // --- Epic ---
-export const epic = handle.epic().on(GlobalActions.logout, () => {
-  return Rx.concatObs(
-    Rx.of(RouterActions.navigate('/login')),
-    Rx.fromPromise(authService.logout()).pipe(Rx.ignoreElements()),
-  );
-});
+let subscribe: (() => void) | null = null;
+export const epic = handle
+  .epic()
+  .on(GlobalActions.$mounted, () => {
+    return new Rx.Observable(subscriber => {
+      subscribe = authService.subscribe(authUser => {
+        subscriber.next(GlobalActions.loggedIn(authUser));
+      });
+    });
+  })
+  .on(GlobalActions.loggedIn, ({ user }) => {
+    const route = user == null ? '/login' : getDefaultRoute();
+    return RouterActions.navigate(route);
+  })
+  .on(GlobalActions.logout, () => {
+    if (subscribe) subscribe();
+    return Rx.from(authService.logout()).pipe(Rx.ignoreElements());
+  });
 
 // --- Reducer ---
 const initialState: GlobalState = {
@@ -23,9 +36,6 @@ export const reducer = handle
   .on(GlobalActions.loggedIn, (state, { user }) => {
     state.isLoaded = true;
     state.user = user == null ? null : { firebaseAuth: user, email: user.email! };
-  })
-  .on(GlobalActions.logout, state => {
-    state.user = null;
   })
   .on(GlobalActions.progressShow, state => {
     state.progress = true;

--- a/packages/front/src/bibliotheca/features/inventory/routes.tsx
+++ b/packages/front/src/bibliotheca/features/inventory/routes.tsx
@@ -4,21 +4,34 @@ import React from 'react';
 import { InventoryEventModule } from './inventoryEvent/module';
 import { RegisterInventoryBookModule } from './inventoryEvent/registerInventoryBook/module';
 import { InventoryEventLogModule } from './inventoryEventLog/module';
+import { Dashboard } from 'bibliotheca/components/Dashboard';
 
 // --- Routing ---
 export default withAuthentication(
   mount({
     '/': route({
       title: '棚卸し - Bibliotheca',
-      view: <InventoryEventModule />,
+      view: (
+        <Dashboard>
+          <InventoryEventModule />
+        </Dashboard>
+      ),
     }),
     '/logs': route({
       title: '棚卸し一覧 - Bibliotheca',
-      view: <InventoryEventLogModule />,
+      view: (
+        <Dashboard>
+          <InventoryEventLogModule />
+        </Dashboard>
+      ),
     }),
     '/register-book': route({
       title: '棚卸し - Bibliotheca',
-      view: <RegisterInventoryBookModule />,
+      view: (
+        <Dashboard>
+          <RegisterInventoryBookModule />
+        </Dashboard>
+      ),
     }),
   }),
 );

--- a/packages/front/src/bibliotheca/features/inventory/routes.tsx
+++ b/packages/front/src/bibliotheca/features/inventory/routes.tsx
@@ -1,5 +1,4 @@
 import { withAuthentication } from 'bibliotheca/routes';
-import { AppContext } from 'bibliotheca/types';
 import { mount, route } from 'navi';
 import React from 'react';
 import { InventoryEventModule } from './inventoryEvent/module';
@@ -8,7 +7,7 @@ import { InventoryEventLogModule } from './inventoryEventLog/module';
 
 // --- Routing ---
 export default withAuthentication(
-  mount<AppContext>({
+  mount({
     '/': route({
       title: '棚卸し - Bibliotheca',
       view: <InventoryEventModule />,

--- a/packages/front/src/bibliotheca/features/login/routes.tsx
+++ b/packages/front/src/bibliotheca/features/login/routes.tsx
@@ -1,11 +1,10 @@
 import { withRedirectIfLoggedIn } from 'bibliotheca/routes';
-import { AppContext } from 'bibliotheca/types';
 import { mount, route } from 'navi';
 import React from 'react';
 import { LoginModule } from './module';
 
 // --- Routing ---
-export default mount<AppContext>({
+export default mount({
   '/': withRedirectIfLoggedIn(
     route({
       title: 'ログイン - Bibliotheca',

--- a/packages/front/src/bibliotheca/features/management/routes.tsx
+++ b/packages/front/src/bibliotheca/features/management/routes.tsx
@@ -2,12 +2,17 @@ import { withAuthentication } from 'bibliotheca/routes';
 import { mount, route } from 'navi';
 import React from 'react';
 import { ManagementModule } from './module';
+import { Dashboard } from 'bibliotheca/components/Dashboard';
 
 export default mount({
   '/': withAuthentication(
     route({
       title: 'Management',
-      view: <ManagementModule />,
+      view: (
+        <Dashboard>
+          <ManagementModule />
+        </Dashboard>
+      ),
     }),
   ),
 });

--- a/packages/front/src/bibliotheca/features/management/routes.tsx
+++ b/packages/front/src/bibliotheca/features/management/routes.tsx
@@ -1,10 +1,9 @@
 import { withAuthentication } from 'bibliotheca/routes';
-import { AppContext } from 'bibliotheca/types';
 import { mount, route } from 'navi';
 import React from 'react';
 import { ManagementModule } from './module';
 
-export default mount<AppContext>({
+export default mount({
   '/': withAuthentication(
     route({
       title: 'Management',

--- a/packages/front/src/bibliotheca/features/user/routes.tsx
+++ b/packages/front/src/bibliotheca/features/user/routes.tsx
@@ -1,11 +1,10 @@
 import { withAuthentication } from 'bibliotheca/routes';
-import { AppContext } from 'bibliotheca/types';
 import { mount, route } from 'navi';
 import React from 'react';
 import { UserModule } from './module';
 
 export default withAuthentication(
-  mount<AppContext>({
+  mount({
     '/:userId': route({
       title: 'ユーザ - Bibliotheca',
       getView: req => <UserModule userId={req.params.userId} />,

--- a/packages/front/src/bibliotheca/features/user/routes.tsx
+++ b/packages/front/src/bibliotheca/features/user/routes.tsx
@@ -2,12 +2,17 @@ import { withAuthentication } from 'bibliotheca/routes';
 import { mount, route } from 'navi';
 import React from 'react';
 import { UserModule } from './module';
+import { Dashboard } from 'bibliotheca/components/Dashboard';
 
 export default withAuthentication(
   mount({
     '/:userId': route({
       title: 'ユーザ - Bibliotheca',
-      getView: req => <UserModule userId={req.params.userId} />,
+      getView: req => (
+        <Dashboard>
+          <UserModule userId={req.params.userId} />
+        </Dashboard>
+      ),
     }),
   }),
 );

--- a/packages/front/src/bibliotheca/routes.ts
+++ b/packages/front/src/bibliotheca/routes.ts
@@ -1,12 +1,9 @@
-import { AppContext, RouteEntry } from 'bibliotheca/types';
+import { RouteEntry } from 'bibliotheca/types';
 import { createBrowserNavigation, map, Matcher, mount, redirect } from 'navi';
-import {
-  decideRedirectUrlFromRequest,
-  getDefaultRoute,
-  makeLoginUrlForRedirectFromRequest,
-} from './features/router/helper';
+import { getGlobalState } from './features/global/interface';
+import { decideRedirectUrlFromRequest, getDefaultRoute, makeLoginUrlForRedirectFromRequest } from './features/router/helper';
 
-const staticRoute: Record<string, Matcher<AppContext>> = {
+const staticRoute: Record<string, Matcher<any>> = {
   '/': redirect(getDefaultRoute()),
 };
 
@@ -23,25 +20,22 @@ const resolveRoutes = () => {
     return { ...acc, ...{ [routeEntry.path]: routeEntry.routes } };
   }, {});
 
-  return mount<AppContext>({ ...matcherEntry, ...staticRoute });
+  return mount({ ...matcherEntry, ...staticRoute });
 };
 
 const routes = resolveRoutes();
-export const navigation = createBrowserNavigation<AppContext>({ routes });
+export const navigation = createBrowserNavigation({ routes });
 
-export function withAuthentication(matcher: Matcher<AppContext>) {
-  return map<AppContext>(async (request, context) => {
-    // wait for global state
-    await context.isLoadedAsync;
-
-    return context.user ? matcher : redirect(makeLoginUrlForRedirectFromRequest(request));
+export function withAuthentication(matcher: Matcher<any, any>) {
+  return map(request => {
+    const { user } = getGlobalState();
+    return user ? matcher : redirect(makeLoginUrlForRedirectFromRequest(request));
   });
 }
 
-export const withRedirectIfLoggedIn = (matcher: Matcher<AppContext>) => {
-  return map<AppContext>(async (request, context) => {
-    await context.isLoadedAsync;
-
-    return context.user ? redirect(decideRedirectUrlFromRequest(request)) : matcher;
+export const withRedirectIfLoggedIn = (matcher: Matcher<any, any>) => {
+  return map(request => {
+    const { user } = getGlobalState();
+    return user ? redirect(decideRedirectUrlFromRequest(request)) : matcher;
   });
 };

--- a/packages/front/src/bibliotheca/routes.ts
+++ b/packages/front/src/bibliotheca/routes.ts
@@ -1,7 +1,11 @@
 import { RouteEntry } from 'bibliotheca/types';
 import { createBrowserNavigation, map, Matcher, mount, redirect } from 'navi';
 import { getGlobalState } from './features/global/interface';
-import { decideRedirectUrlFromRequest, getDefaultRoute, makeLoginUrlForRedirectFromRequest } from './features/router/helper';
+import {
+  decideRedirectUrlFromRequest,
+  getDefaultRoute,
+  makeLoginUrlForRedirectFromRequest,
+} from './features/router/helper';
 
 const staticRoute: Record<string, Matcher<any>> = {
   '/': redirect(getDefaultRoute()),

--- a/packages/front/src/bibliotheca/types.ts
+++ b/packages/front/src/bibliotheca/types.ts
@@ -2,17 +2,9 @@ import { User as FirebaseUser } from 'firebase/app';
 import { Matcher } from 'navi';
 import React from 'react';
 
-export interface AppContext {
-  user: User | null;
-  isLoadedAsync: Promise<void>;
-}
-
-export interface RouteEntry<
-  Context extends object = AppContext,
-  ChildContext extends object = Context
-> {
+export interface RouteEntry {
   path: string;
-  routes: Matcher<Context, ChildContext>;
+  routes: Matcher<object>;
 }
 
 export interface User {


### PR DESCRIPTION
`Layout` Componentがnaviの `View` Copmonentの親にあり、`Layout` は `GlobalModule` の `user` に依存している
したがって、`user` が更新されると `Layout` の再レンダリングが走り、 `View` もそれに巻き込まれる
logoutを実施すると、naviのnavigate処理よりも `Layout` の再レンダリングが先に評価され、結果として `Layout` 再描画→ `View`再描画→ navigate to loginという順序になってアカン