### PR TITLE
feat: 棚卸し wip

### DIFF
--- a/packages/front/src/bibliotheca/features/inventory/inventoryBookModule/module.ts
+++ b/packages/front/src/bibliotheca/features/inventory/inventoryBookModule/module.ts
@@ -46,7 +46,7 @@ export const reducer = handle
     state.event = event;
   })
   .on(InventoryBookModuleActions.fetchBookListFullfilled, (state, { books }) => {
-    state.booksInList = books;
+    state.booksInList = books.filter(b => b.deletedAt == null);
   });
 
 // --- Module ---

--- a/packages/front/src/bibliotheca/features/inventory/inventoryEvent/components/InventoryDoing.tsx
+++ b/packages/front/src/bibliotheca/features/inventory/inventoryEvent/components/InventoryDoing.tsx
@@ -1,7 +1,7 @@
 import { Link } from 'bibliotheca/components/Link';
 import { StyledDataTable } from 'bibliotheca/components/StyledDataTable';
 import { findUncheckedOnlyList } from 'bibliotheca/services/inventory/query';
-import { InventoryEventDoing } from 'bibliotheca/types';
+import { InventoryEventDoing, Book } from 'bibliotheca/types';
 import { Button, RadioButton, Text } from 'grommet';
 import React from 'react';
 import { useActions, useMappedState } from 'typeless';
@@ -9,7 +9,9 @@ import { getInventoryBookModuleState } from '../../inventoryBookModule/interface
 import { getInventoryEventState, InventoryEventActions } from '../interface';
 
 export const InventoryDoing = () => {
-  const { changeView, toMissingAll, submitInventory } = useActions(InventoryEventActions);
+  const { changeView, toMissingAll, submitInventory, toCheckStatus } = useActions(
+    InventoryEventActions,
+  );
   const { canChangeMissingAll, books, viewType } = useMappedState(
     [getInventoryBookModuleState, getInventoryEventState],
     ({ booksInList, event }, { viewType }) => {
@@ -101,6 +103,13 @@ export const InventoryDoing = () => {
           // todo: localization status
           { property: 'status', header: '棚卸しステータス' },
           // todo: can change book status(`missing` or `checked`) from list
+          {
+            property: '',
+            header: '操作',
+            render: (book: Book) => {
+              return <Button label="チェックする" onClick={() => toCheckStatus(book)}></Button>;
+            },
+          },
           // todo: display borrowedBy
         ]}
         sortable

--- a/packages/front/src/bibliotheca/features/inventory/inventoryEvent/components/InventoryDoing.tsx
+++ b/packages/front/src/bibliotheca/features/inventory/inventoryEvent/components/InventoryDoing.tsx
@@ -1,55 +1,27 @@
 import { Link } from 'bibliotheca/components/Link';
 import { StyledDataTable } from 'bibliotheca/components/StyledDataTable';
-import { findUncheckedOnlyList } from 'bibliotheca/services/inventory/query';
-import { InventoryEventDoing, Book } from 'bibliotheca/types';
+import { Book, InventoryStatus } from 'bibliotheca/types';
 import { Button, RadioButton, Text } from 'grommet';
 import React from 'react';
-import { useActions, useMappedState } from 'typeless';
-import { getInventoryBookModuleState } from '../../inventoryBookModule/interface';
-import { getInventoryEventState, InventoryEventActions } from '../interface';
+import { useActions } from 'typeless';
+import { InventoryEventActions, ViewType } from '../interface';
 
-export const InventoryDoing = () => {
+type BookForTable = Book & { status: InventoryStatus; key: number };
+type InventoryEventDoingProps = {
+  canChangeMissingAll: boolean;
+  books: BookForTable[];
+  viewType: ViewType;
+};
+
+export const InventoryDoing = ({
+  canChangeMissingAll,
+  viewType,
+  books,
+}: InventoryEventDoingProps) => {
   const { changeView, toMissingAll, submitInventory, toCheckStatus } = useActions(
     InventoryEventActions,
   );
-  const { canChangeMissingAll, books, viewType } = useMappedState(
-    [getInventoryBookModuleState, getInventoryEventState],
-    ({ booksInList, event }, { viewType }) => {
-      const uncheckedBooks = findUncheckedOnlyList(
-        (event as InventoryEventDoing).inventoryBooks,
-        booksInList,
-      );
-      const canChangeMissingAll = uncheckedBooks.length === 0;
-      const books = ((e: InventoryEventDoing) => {
-        switch (viewType) {
-          case 'checkedOnly':
-            return e.inventoryBooks.map(({ status, bookId }) => ({
-              status,
-              ...booksInList.find(b => b.id === bookId)!,
-            }));
-          case 'all':
-            return booksInList.map(b => {
-              const inventoryBook = e.inventoryBooks.find(ib => ib.bookId === b.id);
-              if (inventoryBook) {
-                return { status: inventoryBook.status, ...b };
-              } else {
-                return { status: 'unchecked', ...b };
-              }
-            });
-          case 'uncheckedOnly': {
-            return uncheckedBooks;
-          }
-          default:
-            throw new Error('unknown mode');
-        }
-      })(event as InventoryEventDoing);
-      return {
-        viewType,
-        books: books.map((b, i) => ({ ...b, key: i })),
-        canChangeMissingAll,
-      };
-    },
-  );
+
   return (
     <>
       <Link href={`/inventory-event/register-book`}>

--- a/packages/front/src/bibliotheca/features/inventory/inventoryEvent/components/InventoryDoing.tsx
+++ b/packages/front/src/bibliotheca/features/inventory/inventoryEvent/components/InventoryDoing.tsx
@@ -1,6 +1,6 @@
 import { Link } from 'bibliotheca/components/Link';
 import { StyledDataTable } from 'bibliotheca/components/StyledDataTable';
-import { Book, InventoryStatus, InventoryStatusText } from 'bibliotheca/types';
+import { Book, InventoryStatus, InventoryStatusText, isBook } from 'bibliotheca/types';
 import { Button, RadioButton, Text, Box } from 'grommet';
 import React from 'react';
 import { useActions } from 'typeless';
@@ -106,7 +106,11 @@ export const InventoryDoing = ({
               );
             },
           },
-          // todo: display borrowedBy
+          {
+            property: 'borrowedBy',
+            header: '借りてる人',
+            render: (book: Partial<Book>) => book.borrowedBy,
+          },
         ]}
         sortable
       />

--- a/packages/front/src/bibliotheca/features/inventory/inventoryEvent/components/InventoryDoing.tsx
+++ b/packages/front/src/bibliotheca/features/inventory/inventoryEvent/components/InventoryDoing.tsx
@@ -1,10 +1,11 @@
 import { Link } from 'bibliotheca/components/Link';
 import { StyledDataTable } from 'bibliotheca/components/StyledDataTable';
-import { Book, InventoryStatus } from 'bibliotheca/types';
-import { Button, RadioButton, Text } from 'grommet';
+import { Book, InventoryStatus, InventoryStatusText } from 'bibliotheca/types';
+import { Button, RadioButton, Text, Box } from 'grommet';
 import React from 'react';
 import { useActions } from 'typeless';
 import { InventoryEventActions, ViewType } from '../interface';
+import { FormCheckmark as FormCheckmarkIcon, FormClose as FormCloseIcon } from 'grommet-icons';
 
 type BookForTable = Book & { status: InventoryStatus; key: number };
 type InventoryEventDoingProps = {
@@ -18,7 +19,7 @@ export const InventoryDoing = ({
   viewType,
   books,
 }: InventoryEventDoingProps) => {
-  const { changeView, toMissingAll, submitInventory, toCheckStatus } = useActions(
+  const { changeView, toMissingAll, submitInventory, changeStatus } = useActions(
     InventoryEventActions,
   );
 
@@ -72,14 +73,37 @@ export const InventoryDoing = ({
             },
           },
           { property: 'isbn', header: 'ISBN' },
-          // todo: localization status
-          { property: 'status', header: '棚卸しステータス' },
-          // todo: can change book status(`missing` or `checked`) from list
+          {
+            property: 'status',
+            header: '棚卸しステータス',
+            render: (book: BookForTable) => {
+              return (
+                <Text color={book.status === 'missing' ? 'status-critical' : ''}>
+                  {InventoryStatusText[book.status]}
+                </Text>
+              );
+            },
+          },
           {
             property: '',
             header: '操作',
-            render: (book: Book) => {
-              return <Button label="チェックする" onClick={() => toCheckStatus(book)}></Button>;
+            render: (book: BookForTable) => {
+              return (
+                <Box gap="xsmall" direction="row">
+                  <Button
+                    icon={<FormCheckmarkIcon />}
+                    plain={false}
+                    disabled={book.status === 'checked'}
+                    onClick={() => changeStatus(book, 'checked')}
+                  />
+                  <Button
+                    icon={<FormCloseIcon />}
+                    plain={false}
+                    disabled={book.status === 'missing'}
+                    onClick={() => changeStatus(book, 'missing')}
+                  />
+                </Box>
+              );
             },
           },
           // todo: display borrowedBy

--- a/packages/front/src/bibliotheca/features/inventory/inventoryEvent/components/InventoryDoing.tsx
+++ b/packages/front/src/bibliotheca/features/inventory/inventoryEvent/components/InventoryDoing.tsx
@@ -64,7 +64,7 @@ export const InventoryDoing = ({
             property: 'title',
             header: 'タイトル',
             search: true,
-            render: (book: { id: string; title: string }) => {
+            render: (book: BookForTable) => {
               return (
                 <Link href={`/books/${book.id}`}>
                   <Text>{book.title}</Text>

--- a/packages/front/src/bibliotheca/features/inventory/inventoryEvent/components/InventoryDoing.tsx
+++ b/packages/front/src/bibliotheca/features/inventory/inventoryEvent/components/InventoryDoing.tsx
@@ -1,11 +1,11 @@
 import { Link } from 'bibliotheca/components/Link';
 import { StyledDataTable } from 'bibliotheca/components/StyledDataTable';
-import { Book, InventoryStatus, InventoryStatusText, isBook } from 'bibliotheca/types';
-import { Button, RadioButton, Text, Box } from 'grommet';
+import { Book, InventoryStatus, InventoryStatusText } from 'bibliotheca/types';
+import { Box, Button, RadioButton, Text } from 'grommet';
+import { FormCheckmark as FormCheckmarkIcon, FormClose as FormCloseIcon } from 'grommet-icons';
 import React from 'react';
 import { useActions } from 'typeless';
 import { InventoryEventActions, ViewType } from '../interface';
-import { FormCheckmark as FormCheckmarkIcon, FormClose as FormCloseIcon } from 'grommet-icons';
 
 type BookForTable = Book & { status: InventoryStatus; key: number };
 type InventoryEventDoingProps = {

--- a/packages/front/src/bibliotheca/features/inventory/inventoryEvent/components/InventoryEventView.tsx
+++ b/packages/front/src/bibliotheca/features/inventory/inventoryEvent/components/InventoryEventView.tsx
@@ -12,8 +12,9 @@ export const InventoryEventView = () => {
   const states = useMappedState(
     [getInventoryBookModuleState, getInventoryEventState],
     ({ booksInList, event }, { viewType }) => {
-      if (!event) {
-        return { event };
+      if (!event) return undefined;
+      if (event.status === 'done') {
+        return { eventStatus: event.status };
       }
 
       const uncheckedBooks = findUncheckedOnlyList(
@@ -45,7 +46,7 @@ export const InventoryEventView = () => {
         }
       })(event as InventoryEventDoing);
       return {
-        event,
+        eventStatus: event.status,
         viewType,
         books: books.map((b, i) => ({ ...b, key: i })),
         canChangeMissingAll,
@@ -54,12 +55,12 @@ export const InventoryEventView = () => {
   );
 
   let component: JSX.Element | string;
-  if (states.event == null) {
+  if (states === undefined) {
     component = 'Loading...';
   } else {
-    switch (states.event.status) {
+    switch (states.eventStatus) {
       case InventoryEventStatus.Doing:
-        const { event: _, ...props } = states;
+        const { eventStatus: _, ...props } = states;
         component = <InventoryDoing {...props} />;
         break;
       case InventoryEventStatus.Done:

--- a/packages/front/src/bibliotheca/features/inventory/inventoryEvent/components/InventoryEventView.tsx
+++ b/packages/front/src/bibliotheca/features/inventory/inventoryEvent/components/InventoryEventView.tsx
@@ -17,10 +17,7 @@ export const InventoryEventView = () => {
         return { eventStatus: event.status };
       }
 
-      const uncheckedBooks = findUncheckedOnlyList(
-        (event as InventoryEventDoing).inventoryBooks,
-        booksInList,
-      );
+      const uncheckedBooks = findUncheckedOnlyList(event.inventoryBooks, booksInList);
       const canChangeMissingAll = uncheckedBooks.length === 0;
       const books = ((e: InventoryEventDoing) => {
         switch (viewType) {

--- a/packages/front/src/bibliotheca/features/inventory/inventoryEvent/components/InventoryEventView.tsx
+++ b/packages/front/src/bibliotheca/features/inventory/inventoryEvent/components/InventoryEventView.tsx
@@ -1,26 +1,74 @@
 import { Link } from 'bibliotheca/components/Link';
-import { InventoryEventStatus } from 'bibliotheca/types';
+import { findUncheckedOnlyList } from 'bibliotheca/services/inventory/query';
+import { InventoryEventDoing, InventoryEventStatus, InventoryStatus } from 'bibliotheca/types';
 import React from 'react';
+import { useMappedState } from 'typeless';
 import { getInventoryBookModuleState } from '../../inventoryBookModule/interface';
+import { getInventoryEventState } from '../interface';
 import { InventoryDoing } from './InventoryDoing';
 import { InventoryDone } from './InventoryDone';
 
 export const InventoryEventView = () => {
-  const { event } = getInventoryBookModuleState.useState();
+  const states = useMappedState(
+    [getInventoryBookModuleState, getInventoryEventState],
+    ({ booksInList, event }, { viewType }) => {
+      if (!event) {
+        return { event };
+      }
 
-  const component = (() => {
-    if (event == null) {
-      return 'Loading...';
-    }
-    switch (event.status) {
+      const uncheckedBooks = findUncheckedOnlyList(
+        (event as InventoryEventDoing).inventoryBooks,
+        booksInList,
+      );
+      const canChangeMissingAll = uncheckedBooks.length === 0;
+      const books = ((e: InventoryEventDoing) => {
+        switch (viewType) {
+          case 'checkedOnly':
+            return e.inventoryBooks.map(({ status, bookId }) => ({
+              status,
+              ...booksInList.find(b => b.id === bookId)!,
+            }));
+          case 'all':
+            return booksInList.map(b => {
+              const inventoryBook = e.inventoryBooks.find(ib => ib.bookId === b.id);
+              if (inventoryBook) {
+                return { status: inventoryBook.status, ...b };
+              } else {
+                return { status: 'unchecked' as InventoryStatus, ...b };
+              }
+            });
+          case 'uncheckedOnly': {
+            return uncheckedBooks;
+          }
+          default:
+            throw new Error('unknown mode');
+        }
+      })(event as InventoryEventDoing);
+      return {
+        event,
+        viewType,
+        books: books.map((b, i) => ({ ...b, key: i })),
+        canChangeMissingAll,
+      };
+    },
+  );
+
+  let component: JSX.Element | string;
+  if (states.event == null) {
+    component = 'Loading...';
+  } else {
+    switch (states.event.status) {
       case InventoryEventStatus.Doing:
-        return <InventoryDoing />;
+        const { event: _, ...props } = states;
+        component = <InventoryDoing {...props} />;
+        break;
       case InventoryEventStatus.Done:
-        return <InventoryDone />;
+        component = <InventoryDone />;
+        break;
       default:
         throw new Error('unknown mode');
     }
-  })();
+  }
   return (
     <>
       <Link href="/inventory-event/logs">過去の棚卸し履歴</Link>

--- a/packages/front/src/bibliotheca/features/inventory/inventoryEvent/interface.ts
+++ b/packages/front/src/bibliotheca/features/inventory/inventoryEvent/interface.ts
@@ -1,5 +1,6 @@
 import { createModule } from 'typeless';
 import { InventoryEventSymbol } from './symbol';
+import { Book } from 'bibliotheca/types';
 
 // --- Actions ---
 export const [handle, InventoryEventActions, getInventoryEventState] = createModule(
@@ -9,6 +10,7 @@ export const [handle, InventoryEventActions, getInventoryEventState] = createMod
     changeView: (type: ViewType) => ({ payload: { type } }),
     toMissingAll: null,
     submitInventory: null,
+    toCheckStatus: (book: Book) => ({ payload: { book } }),
   })
   .withState<InventoryEventState>();
 

--- a/packages/front/src/bibliotheca/features/inventory/inventoryEvent/interface.ts
+++ b/packages/front/src/bibliotheca/features/inventory/inventoryEvent/interface.ts
@@ -1,6 +1,6 @@
 import { createModule } from 'typeless';
 import { InventoryEventSymbol } from './symbol';
-import { Book } from 'bibliotheca/types';
+import { Book, InventoryStatus } from 'bibliotheca/types';
 
 // --- Actions ---
 export const [handle, InventoryEventActions, getInventoryEventState] = createModule(
@@ -10,7 +10,9 @@ export const [handle, InventoryEventActions, getInventoryEventState] = createMod
     changeView: (type: ViewType) => ({ payload: { type } }),
     toMissingAll: null,
     submitInventory: null,
-    toCheckStatus: (book: Book) => ({ payload: { book } }),
+    changeStatus: (book: Book, status: InventoryStatus) => ({
+      payload: { book, status },
+    }),
   })
   .withState<InventoryEventState>();
 

--- a/packages/front/src/bibliotheca/features/inventory/inventoryEvent/module.tsx
+++ b/packages/front/src/bibliotheca/features/inventory/inventoryEvent/module.tsx
@@ -7,16 +7,15 @@ import {
 } from 'bibliotheca/services/ServiceContainer';
 import { InventoryEventDoing } from 'bibliotheca/types';
 import React from 'react';
-import * as Rx from 'typeless/rx';
+import { getInventoryBookModuleState } from '../inventoryBookModule/interface';
 import { useInventoryBookModule } from '../inventoryBookModule/module';
 import { InventoryEventView } from './components/InventoryEventView';
 import { handle, InventoryEventActions, InventoryEventState } from './interface';
-import { getInventoryBookModuleState } from '../inventoryBookModule/interface';
 
 // --- Epic ---
 export const epic = handle
   .epic()
-  .on(InventoryEventActions.toMissingAll, () => {
+  .on(InventoryEventActions.toMissingAll, async () => {
     const { booksInList, event } = getInventoryBookModuleState();
 
     const uncheckedBooks = findUncheckedOnlyList(
@@ -24,23 +23,18 @@ export const epic = handle
       booksInList,
     );
 
-    if (uncheckedBooks.length === 0) return Rx.empty();
+    if (uncheckedBooks.length === 0) return null;
 
     const msg =
       '以下の書籍を紛失状態にします。よろしいですか？' +
       uncheckedBooks.map(b => b.title).join('\n');
     if (window.confirm(msg)) {
-      return Rx.from(
-        inventoryEventRepository.addInventoryBook(
-          uncheckedBooks.map(b => ({ status: 'missing' as const, bookId: b.id })),
-        ),
-      ).pipe(
-        Rx.map(() => {
-          return NotificationActions.notifyMessage('全て紛失ステータスに変えました');
-        }),
+      await inventoryEventRepository.addInventoryBook(
+        uncheckedBooks.map(b => ({ status: 'missing' as const, bookId: b.id })),
       );
+      return NotificationActions.notifyMessage('全て紛失ステータスに変えました');
     } else {
-      return Rx.empty();
+      return null;
     }
   })
   .on(InventoryEventActions.toCheckStatus, async ({ book }) => {
@@ -58,7 +52,7 @@ export const epic = handle
       return null;
     }
   })
-  .on(InventoryEventActions.submitInventory, () => {
+  .on(InventoryEventActions.submitInventory, async () => {
     const msg =
       '棚卸しを完了します。\n＊＊全ての紛失ステータスの書籍が削除されます＊＊\nよろしいですか？';
     if (window.confirm(msg)) {
@@ -74,15 +68,12 @@ export const epic = handle
         .map(b => ({ ...b, deletedAt: new Date() }));
 
       // todo: validate submit if unchecked book exists
-      return Rx.from(
-        (async () => {
-          await inventoryLogRepository.add({ date, status: 'done', books: inventoriedBooks });
-          await inventoryEventRepository.close();
-          await bookRepository.bulkUpdate(missingBooks);
-        })(),
-      ).pipe(Rx.map(() => NotificationActions.notifyMessage('棚卸しを完了しました')));
+      await inventoryLogRepository.add({ date, status: 'done', books: inventoriedBooks });
+      await inventoryEventRepository.close();
+      await bookRepository.bulkUpdate(missingBooks);
+      return NotificationActions.notifyMessage('棚卸しを完了しました');
     } else {
-      return Rx.empty();
+      return null;
     }
   });
 // --- Reducer ---

--- a/packages/front/src/bibliotheca/features/inventory/inventoryEvent/module.tsx
+++ b/packages/front/src/bibliotheca/features/inventory/inventoryEvent/module.tsx
@@ -5,7 +5,7 @@ import {
   inventoryEventRepository,
   inventoryLogRepository,
 } from 'bibliotheca/services/ServiceContainer';
-import { InventoryEventDoing } from 'bibliotheca/types';
+import { InventoryEventDoing, InventoryStatusText } from 'bibliotheca/types';
 import React from 'react';
 import { getInventoryBookModuleState } from '../inventoryBookModule/interface';
 import { useInventoryBookModule } from '../inventoryBookModule/module';
@@ -37,17 +37,19 @@ export const epic = handle
       return null;
     }
   })
-  .on(InventoryEventActions.toCheckStatus, async ({ book }) => {
+  .on(InventoryEventActions.changeStatus, async ({ book, status }) => {
     const { event } = getInventoryBookModuleState();
     const target = (event as InventoryEventDoing).inventoryBooks.find(ib => ib.bookId === book.id);
 
-    if (target && target.status === 'checked') {
+    if (target && target.status === status) {
       return null;
     }
-    const msg = `${book.title} をチェック状態にします。よろしいですか？`;
+    const msg = `${book.title} を${InventoryStatusText[status]}状態にします。よろしいですか？`;
     if (window.confirm(msg)) {
-      await inventoryEventRepository.upsertInventoryBook({ status: 'checked', bookId: book.id });
-      return NotificationActions.notifyMessage(`${book.title} をチェック状態にしました`);
+      await inventoryEventRepository.upsertInventoryBook({ status, bookId: book.id });
+      return NotificationActions.notifyMessage(
+        `${book.title} を${InventoryStatusText[status]}状態にしました`,
+      );
     } else {
       return null;
     }

--- a/packages/front/src/bibliotheca/features/inventory/inventoryEvent/module.tsx
+++ b/packages/front/src/bibliotheca/features/inventory/inventoryEvent/module.tsx
@@ -43,6 +43,21 @@ export const epic = handle
       return Rx.empty();
     }
   })
+  .on(InventoryEventActions.toCheckStatus, async ({ book }) => {
+    const { event } = getInventoryBookModuleState();
+    const target = (event as InventoryEventDoing).inventoryBooks.find(ib => ib.bookId === book.id);
+
+    if (target && target.status === 'checked') {
+      return null;
+    }
+    const msg = `${book.title} をチェック状態にします。よろしいですか？`;
+    if (window.confirm(msg)) {
+      await inventoryEventRepository.upsertInventoryBook({ status: 'checked', bookId: book.id });
+      return NotificationActions.notifyMessage(`${book.title} をチェック状態にしました`);
+    } else {
+      return null;
+    }
+  })
   .on(InventoryEventActions.submitInventory, () => {
     const msg =
       '棚卸しを完了します。\n＊＊全ての紛失ステータスの書籍が削除されます＊＊\nよろしいですか？';

--- a/packages/front/src/bibliotheca/services/InventoryEventRepository.ts
+++ b/packages/front/src/bibliotheca/services/InventoryEventRepository.ts
@@ -87,6 +87,35 @@ export class InventoryEventRepository {
     return this.eventRef.get().then(inventoryEventFromDoc);
   };
 
+  upsertInventoryBook = async (target: InventoryBook | InventoryBook[]) => {
+    await this.db.runTransaction(async tx => {
+      const presentEvent = await tx.get(this.eventRef).then(inventoryEventFromDoc);
+      if (isDoneEvent(presentEvent)) {
+        throw new Error('Invalid update `InventoryEvent`: cannot add book when inventory is done');
+      }
+
+      const targets = Array.isArray(target) ? target : [target];
+      const addition = targets.filter(
+        b => presentEvent.inventoryBooks.find(ib => ib.bookId === b.bookId) === undefined,
+      );
+      const updated = presentEvent.inventoryBooks.map(ib => {
+        const t = targets.find(b => b.bookId === ib.bookId);
+        if (t === undefined) {
+          return ib;
+        } else {
+          return t;
+        }
+      });
+      const inventoryBooks = [...updated, ...addition];
+      const newEvent: Pick<InventoryEventDoing, 'inventoryBooks'> = {
+        inventoryBooks,
+      };
+      tx.update(this.eventRef, newEvent);
+      return;
+    });
+    return this.eventRef.get().then(inventoryEventFromDoc);
+  };
+
   subscribeInventoryBooks = (observer: (event: InventoryEvent) => void) =>
     this.collection.onSnapshot(snapshot => {
       observer(snapshot.docs.map(inventoryEventFromDoc)[0]);

--- a/packages/front/src/bibliotheca/services/inventory/query.ts
+++ b/packages/front/src/bibliotheca/services/inventory/query.ts
@@ -1,4 +1,4 @@
-import { InventoryBook, Book, InventoryStatus } from 'bibliotheca/types';
+import { Book, InventoryBook, InventoryStatus } from 'bibliotheca/types';
 
 export function findUncheckedOnlyList(inventoryBooks: InventoryBook[], booksInList: Book[]) {
   const checked = new Set(inventoryBooks.map(b => b.bookId));

--- a/packages/front/src/bibliotheca/types.ts
+++ b/packages/front/src/bibliotheca/types.ts
@@ -47,7 +47,7 @@ export interface BookEditData {
   title: string;
 }
 
-export type InventoryStatus = 'checked' | 'missing';
+export type InventoryStatus = 'checked' | 'missing' | 'unchecked';
 
 export interface InventoryEventDone {
   status: typeof InventoryEventStatus.Done;

--- a/packages/front/src/bibliotheca/types.ts
+++ b/packages/front/src/bibliotheca/types.ts
@@ -49,6 +49,12 @@ export interface BookEditData {
 
 export type InventoryStatus = 'checked' | 'missing' | 'unchecked';
 
+export const InventoryStatusText: { [K in InventoryStatus]: string } = {
+  checked: 'チェック済',
+  missing: '紛失',
+  unchecked: '未チェック',
+};
+
 export interface InventoryEventDone {
   status: typeof InventoryEventStatus.Done;
 }


### PR DESCRIPTION
related #80 

### done

- [x] 一度uncheckedにした本のステータス変更
- [x] 一覧画面からcheck/uncheck出来るようにする←諸説ありそう
  - バーコードがないと棚下ろせないようにしておかないと事故るかもしれないので
  - バーコードがない本の棚卸しのために必要
- [x] テーブルのスタイルを入れる（縞々とhover）
- [x] 棚卸しカメラモード画面が「蔵書登録フォーム」になっている・戻るボタンがほしい
- [x] 同じ書籍を棚下ろすときにbookIdが同じものになっちゃう
- [x] 蔵書データに変更があったときに棚卸し一覧にそれを適用する

