### PR TITLE
fix: 本の詳細画面を直接参照した際にエラーが出ないようにした

### DIFF
--- a/packages/front/src/bibliotheca/features/book/detail/interface.ts
+++ b/packages/front/src/bibliotheca/features/book/detail/interface.ts
@@ -7,6 +7,7 @@ export const [handle, BookDetailActions, getBookDetailState] = createModule(Book
   .withActions({
     $mounted: null,
     $unmounting: null,
+    init: (bookId: string) => ({ payload: { bookId } }),
     findBookById: (bookId: string) => ({ payload: { bookId } }),
     findBookByIdFulfilled: (book: Book) => ({ payload: { book } }),
     findBookByIdFailure: (error: any) => ({ payload: { error } }),

--- a/packages/front/src/bibliotheca/features/book/detail/module.tsx
+++ b/packages/front/src/bibliotheca/features/book/detail/module.tsx
@@ -1,19 +1,18 @@
 import { BookActions } from 'bibliotheca/features/book/interface';
 import { GlobalActions } from 'bibliotheca/features/global/interface';
 import { NotificationActions } from 'bibliotheca/features/notification/interface';
-import { RouterActions, getRouterState } from 'bibliotheca/features/router/interface';
+import { RouterActions } from 'bibliotheca/features/router/interface';
 import * as Rx from 'bibliotheca/rx';
 import { bookRepository } from 'bibliotheca/services/ServiceContainer';
 import React from 'react';
 import { BookDetailView } from './components/BookDetailView';
 import { BookDetailActions, BookDetailState, handle } from './interface';
+import { useActions } from 'typeless';
 
 // --- Epic ---
 export const epic = handle
   .epic()
-  .on(BookDetailActions.$mounted, () => {
-    const location = getRouterState().location!;
-    const bookId = location.request!.params.bookId;
+  .on(BookDetailActions.init, ({ bookId }) => {
     return !bookId
       ? Rx.of(RouterActions.navigate('/'))
       : Rx.of(BookDetailActions.findBookById(bookId), GlobalActions.progressShow());
@@ -69,7 +68,11 @@ export const reducer = handle
   );
 
 // --- Module ---
-export const BookDetailModule = () => {
+export const BookDetailModule = ({ bookId }: { bookId: string }) => {
   handle();
+
+  const { init } = useActions(BookDetailActions);
+  init(bookId);
+
   return <BookDetailView />;
 };

--- a/packages/front/src/bibliotheca/features/book/routes.tsx
+++ b/packages/front/src/bibliotheca/features/book/routes.tsx
@@ -18,13 +18,15 @@ export default withAuthentication(
         </Dashboard>
       ),
     }),
-    '/:bookId': route({
-      title: '書籍詳細 - Bibliotheca',
-      view: (
-        <Dashboard>
-          <BookDetailModule />
-        </Dashboard>
-      ),
+    '/:bookId': route(async req => {
+      return {
+        title: '書籍詳細 - Bibliotheca',
+        view: (
+          <Dashboard>
+            <BookDetailModule bookId={req.params.bookId} />
+          </Dashboard>
+        ),
+      };
     }),
     '/register': route({
       title: '書籍登録 - Bibliotheca',

--- a/packages/front/src/bibliotheca/features/router/interface.ts
+++ b/packages/front/src/bibliotheca/features/router/interface.ts
@@ -14,9 +14,9 @@ export const [handle, RouterActions, getRouterState] = createModule(RouterSymbol
 // --- Types ---
 export type RouterNavigation = string | Partial<URLDescriptor>;
 export interface RouterLocation {
-  url: URLDescriptor;
-  state?: object;
   request?: NaviRequest;
+  state?: object;
+  url: URLDescriptor;
 }
 
 export interface RouterState {


### PR DESCRIPTION
fixes #124

navi の内部的な挙動も確認した結果、同期的に取得できる情報はそのまま使った方が良いことがわかった。
`Navigation#subscribe` で取得した `route.type === 'ready'` のデータは VDOM に反映した後に来ているのでそれを見てもすでに遅いケースがある。