### PR TITLE
Feat/deleted book collection

### DIFF
--- a/packages/front/src/bibliotheca/features/book/bookList/components/BookListView.tsx
+++ b/packages/front/src/bibliotheca/features/book/bookList/components/BookListView.tsx
@@ -36,7 +36,7 @@ export const BookListView = () => {
       <StyledDataTable
         size={groupBy ? '' : 'large'} // groupBy の際にこの項目が指定されていると適切に表を表示するために各セルの width を自前で調整する必要が出てきてしまう
         primaryKey="id"
-        data={books.filter(b => b.deletedAt == null)}
+        data={books}
         groupBy={groupBy}
         columns={[
           {

--- a/packages/front/src/bibliotheca/features/book/module.tsx
+++ b/packages/front/src/bibliotheca/features/book/module.tsx
@@ -1,5 +1,5 @@
 import * as Rx from 'bibliotheca/rx';
-import { bookRepository } from 'bibliotheca/services/ServiceContainer';
+import { bookRepository, deletedBookRepository } from 'bibliotheca/services/ServiceContainer';
 import { userIdQuery } from '../global/query';
 import { BookActions, handle } from './interface';
 import { getGlobalState } from '../global/interface';
@@ -37,7 +37,7 @@ export const epic = handle
     );
   })
   .on(BookActions.deleteBookById, ({ bookId }) => {
-    return Rx.from(bookRepository.deleteBookById(bookId)).pipe(
+    return Rx.from(deletedBookRepository.deleteById(bookId)).pipe(
       Rx.map(BookActions.deleteBookByIdFulfilled),
     );
   })

--- a/packages/front/src/bibliotheca/features/inventory/inventoryBookModule/module.ts
+++ b/packages/front/src/bibliotheca/features/inventory/inventoryBookModule/module.ts
@@ -46,7 +46,7 @@ export const reducer = handle
     state.event = event;
   })
   .on(InventoryBookModuleActions.fetchBookListFullfilled, (state, { books }) => {
-    state.booksInList = books.filter(b => b.deletedAt == null);
+    state.booksInList = books;
   });
 
 // --- Module ---

--- a/packages/front/src/bibliotheca/features/inventory/inventoryEvent/module.tsx
+++ b/packages/front/src/bibliotheca/features/inventory/inventoryEvent/module.tsx
@@ -67,7 +67,7 @@ export const epic = handle
 
       const missingBooks = inventoriedBooks
         .filter(ib => ib.status === 'missing')
-        .map(b => ({ ...b, deletedAt: new Date() }));
+        .map(({ status: _, ...b }) => ({ ...b }));
 
       // todo: validate submit if unchecked book exists
       await inventoryLogRepository.add({ date, status: 'done', books: inventoriedBooks });

--- a/packages/front/src/bibliotheca/features/inventory/inventoryEvent/module.tsx
+++ b/packages/front/src/bibliotheca/features/inventory/inventoryEvent/module.tsx
@@ -1,9 +1,9 @@
 import { NotificationActions } from 'bibliotheca/features/notification/interface';
 import { findUncheckedOnlyList } from 'bibliotheca/services/inventory/query';
 import {
-  bookRepository,
   inventoryEventRepository,
   inventoryLogRepository,
+  deletedBookRepository,
 } from 'bibliotheca/services/ServiceContainer';
 import { InventoryEventDoing, InventoryStatusText } from 'bibliotheca/types';
 import React from 'react';
@@ -72,7 +72,7 @@ export const epic = handle
       // todo: validate submit if unchecked book exists
       await inventoryLogRepository.add({ date, status: 'done', books: inventoriedBooks });
       await inventoryEventRepository.close();
-      await bookRepository.bulkUpdate(missingBooks);
+      await deletedBookRepository.bulkDelete(missingBooks);
       return NotificationActions.notifyMessage('棚卸しを完了しました');
     } else {
       return null;

--- a/packages/front/src/bibliotheca/services/ServiceContainer.ts
+++ b/packages/front/src/bibliotheca/services/ServiceContainer.ts
@@ -1,4 +1,4 @@
-import { BookRepository } from 'shared/lib/es';
+import { BookRepository, DeletedBookRepository } from 'shared/lib/es';
 import { AuthService } from './AuthService';
 import { firebase } from './firebase';
 import { InventoryEventRepository } from './InventoryEventRepository';
@@ -7,6 +7,7 @@ import { InventoryLogRepository } from './InventoryLogRepository';
 class ServiceContainer {
   authService = new AuthService(firebase.auth());
   bookRepository = new BookRepository(firebase.firestore());
+  deletedBookRepository = new DeletedBookRepository(firebase.firestore(), this.bookRepository);
   inventoryEventRepository = new InventoryEventRepository(firebase.firestore());
   inventoryLogRepository = new InventoryLogRepository(firebase.firestore());
 }
@@ -16,3 +17,4 @@ export const authService = container.authService;
 export const bookRepository = container.bookRepository;
 export const inventoryEventRepository = container.inventoryEventRepository;
 export const inventoryLogRepository = container.inventoryLogRepository;
+export const deletedBookRepository = container.deletedBookRepository;

--- a/packages/front/src/bibliotheca/types.ts
+++ b/packages/front/src/bibliotheca/types.ts
@@ -23,7 +23,6 @@ export interface Book {
   borrowedBy: string | null;
   updatedAt: Date;
   createdAt: Date;
-  deletedAt?: Date;
 }
 
 export const isBook = (book: any): book is Book => {
@@ -80,6 +79,7 @@ export type InventoryEventStatus = typeof InventoryEventStatus[keyof typeof Inve
 export const isDoneEvent = (e: InventoryEvent): e is InventoryEventDone =>
   e.status === InventoryEventStatus.Done;
 
+// todo: Book型に代入できちゃう構造なのを直したい
 interface InventoriedBook extends Book {
   status: InventoryStatus;
 }

--- a/packages/functions/src/bookList/index.ts
+++ b/packages/functions/src/bookList/index.ts
@@ -15,7 +15,7 @@ export function initOnBookWrite(bookRepository: BookRepositoryForBatch) {
 
     if (!change.before.exists) {
       console.log(`作成: ${bookId}`);
-      await bookRepository.addBookToChach({ id: bookId, data: change.after.data() as any });
+      await bookRepository.addBookToCache({ id: bookId, data: change.after.data() as any });
     } else if (!change.after.exists) {
       console.log(`削除: ${bookId}`);
       await bookRepository.deleteBookFromCache(bookId);

--- a/packages/shared/src/repositories/BookRepository.ts
+++ b/packages/shared/src/repositories/BookRepository.ts
@@ -33,7 +33,7 @@ const bookFromEntry = (entry: BookEntry): Book => {
 };
 
 export class BookRepository {
-  protected collection = this.db.collection('books');
+  readonly collection = this.db.collection('books');
   protected bookListsCollection = this.db.collection('bookLists');
 
   constructor(protected db: myFirestore.Firestore) {}
@@ -42,12 +42,9 @@ export class BookRepository {
   findAllCachedBooks = async (): Promise<Book[]> => {
     const querySnapshot = await this.bookListsCollection.get();
 
-    return querySnapshot.docs.reduce(
-      (acc, doc) => {
-        return [...acc, ...(doc.data() as any).entries.map(bookFromEntry)];
-      },
-      [] as Book[],
-    );
+    return querySnapshot.docs.reduce((acc, doc) => {
+      return [...acc, ...(doc.data() as any).entries.map(bookFromEntry)];
+    }, [] as Book[]);
   };
 
   // todo: filter deletedAt
@@ -220,5 +217,5 @@ export class BookRepository {
     await batch.commit();
   };
 
-  private mkBookRefById = (bookId: string): myFirestore.DocumentReference => this.collection.doc(bookId);
+  mkBookRefById = (bookId: string): myFirestore.DocumentReference => this.collection.doc(bookId);
 }

--- a/packages/shared/src/repositories/BookRepositoryForBatch.ts
+++ b/packages/shared/src/repositories/BookRepositoryForBatch.ts
@@ -25,7 +25,7 @@ export class BookRepositoryForBatch extends BookRepository {
     return this.writeBookEntries(bookEntries);
   };
 
-  addBookToChach = async (book: BookEntry) => {
+  addBookToCache = async (book: BookEntry) => {
     await this.db.runTransaction(async tx => {
       const cacheRef = this.bookListsCollection.doc('0');
       const cachedBooksDoc = await tx.get(cacheRef);

--- a/packages/shared/src/repositories/BookRepositoryForBatch.ts
+++ b/packages/shared/src/repositories/BookRepositoryForBatch.ts
@@ -2,26 +2,18 @@ import { BookRepository } from './BookRepository';
 
 type Book = { createdAt: Date };
 type BookEntry = { id: string; data: Book };
+type BookList = { entries: BookEntry[] };
 
 // todo: 要リファクタ。テストがないので一旦ベタ移植だけにとどめた
 export class BookRepositoryForBatch extends BookRepository {
-  fetchCachedBookEntriesMapAsync = async (): Promise<BookEntry[]> => {
-    const doc = await this.db
-      .collection('bookLists')
-      .doc('0') // 未来でページングするかも
-      .get();
-    const data = doc.data();
-    return !data ? [] : (data as any).entries;
-  };
-
-  fetchFreshBookEntriesAsync = async (): Promise<BookEntry[]> => {
+  private fetchFreshBookEntriesAsync = async (): Promise<BookEntry[]> => {
     const qs = await this.db
       .collection('books')
       .orderBy('createdAt')
       .get();
     return qs.docs.map(doc => ({ id: doc.id, data: doc.data() as any }));
   };
-  writeBookEntries = async (bookEntries: BookEntry[]) => {
+  private writeBookEntries = async (bookEntries: BookEntry[]) => {
     return this.db
       .collection('bookLists')
       .doc('0')
@@ -31,5 +23,48 @@ export class BookRepositoryForBatch extends BookRepository {
   writeAllBook = async () => {
     const bookEntries = await this.fetchFreshBookEntriesAsync();
     return this.writeBookEntries(bookEntries);
+  };
+
+  addBookToChach = async (book: BookEntry) => {
+    await this.db.runTransaction(async tx => {
+      const cacheRef = this.bookListsCollection.doc('0');
+      const cachedBooksDoc = await tx.get(cacheRef);
+      const cachedBookEntries: BookEntry[] = cachedBooksDoc.data()?.entries ?? [];
+
+      const newCache: BookList = {
+        entries: [...cachedBookEntries, book],
+      };
+      tx.set(cacheRef, newCache);
+    });
+  };
+
+  editBookInCache = async (book: BookEntry) => {
+    await this.db.runTransaction(async tx => {
+      const cacheRef = this.bookListsCollection.doc('0');
+      const cachedBooksDoc = await tx.get(cacheRef);
+      const cachedBookEntries: BookEntry[] = cachedBooksDoc.data()?.entries ?? [];
+
+      const newCache: BookList = {
+        entries: cachedBookEntries.map(entry => {
+          if (entry.id === book.id) {
+            return book;
+          } else {
+            return entry;
+          }
+        }),
+      };
+      tx.set(cacheRef, newCache);
+    });
+  };
+
+  deleteBookFromCache = async (bookId: string) => {
+    await this.db.runTransaction(async tx => {
+      const cacheRef = this.bookListsCollection.doc('0');
+      const cachedBooksDoc = await tx.get(cacheRef);
+      const cachedBookEntries: BookEntry[] = cachedBooksDoc.data()?.entries ?? [];
+
+      const newCache: BookList = { entries: cachedBookEntries.filter(e => e.id !== bookId) };
+      tx.set(cacheRef, newCache);
+    });
   };
 }

--- a/packages/shared/src/repositories/DeletedBookRepository.ts
+++ b/packages/shared/src/repositories/DeletedBookRepository.ts
@@ -1,0 +1,44 @@
+import { myFirestore } from 'firebase';
+import { DeletedBook, BookData, BookEditData, DeletedBookEntry, Book } from '../types';
+import { BookRepository } from './BookRepository';
+
+const deletedBookFromDoc = (doc: myFirestore.DocumentSnapshot): DeletedBook => {
+  const data = doc.data()! as DeletedBookEntry;
+
+  return {
+    id: doc.id,
+    isbn: data.isbn,
+    title: data.title,
+    updatedAt: data.updatedAt.toDate(),
+    createdAt: data.createdAt.toDate(),
+    deletedAt: data.deletedAt.toDate(),
+  };
+};
+
+export class DeletedBookRepository {
+  protected collection = this.db.collection('deletedBooks');
+
+  constructor(protected db: myFirestore.Firestore, private bookRepository: BookRepository) {}
+
+  bulkDelete = async (books: Book[]) => {
+    await this.db.runTransaction(async tx => {
+      books.forEach(book => {
+        const { id, createdAt: _, updatedAt: _1, deletedAt: _2, ...body } = book;
+        const bookRef = this.bookRepository.mkBookRefById(id);
+        tx.delete(bookRef);
+
+        const deletedBookRef = this.mkDeletedBookRefById(id);
+        const deletedBookData: Omit<DeletedBook, 'id'> = {
+          ...body,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          deletedAt: new Date(),
+        };
+        tx.set(deletedBookRef, deletedBookData);
+      });
+    });
+  };
+
+  private mkDeletedBookRefById = (bookId: string): myFirestore.DocumentReference =>
+    this.collection.doc(bookId);
+}

--- a/packages/shared/src/repositories/index.ts
+++ b/packages/shared/src/repositories/index.ts
@@ -1,2 +1,3 @@
 export * from './BookRepository';
+export * from './DeletedBookRepository';
 export * from './BookRepositoryForBatch';

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -1,3 +1,5 @@
+import { myFirestore } from 'firebase';
+
 export interface Book {
   id: string;
   isbn: string | null;
@@ -9,6 +11,22 @@ export interface Book {
 }
 
 export type BookData = Omit<Book, 'id'>;
+
+export interface DeletedBook {
+  id: string;
+  isbn: string | null;
+  title: string;
+  updatedAt: Date;
+  createdAt: Date;
+  deletedAt: Date;
+}
+export interface DeletedBookEntry {
+  isbn: string | null;
+  title: string;
+  updatedAt: myFirestore.Timestamp;
+  createdAt: myFirestore.Timestamp;
+  deletedAt: myFirestore.Timestamp;
+}
 
 export interface BookEditData {
   id: string;

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -7,7 +7,6 @@ export interface Book {
   borrowedBy: string | null;
   updatedAt: Date;
   createdAt: Date;
-  deletedAt?: Date;
 }
 
 export type BookData = Omit<Book, 'id'>;

--- a/packages/shared/typings/browser/firebase.d.ts
+++ b/packages/shared/typings/browser/firebase.d.ts
@@ -5,5 +5,6 @@ declare module 'firebase' {
     export type Firestore = firestore.Firestore;
     export type DocumentSnapshot = firestore.DocumentSnapshot;
     export type DocumentReference = firestore.DocumentReference;
+    export type Timestamp = firestore.Timestamp;
   }
 }

--- a/packages/shared/typings/node/firebase.d.ts
+++ b/packages/shared/typings/node/firebase.d.ts
@@ -5,5 +5,6 @@ declare module 'firebase' {
     export type Firestore = adminFirestore.Firestore;
     export type DocumentSnapshot = adminFirestore.DocumentSnapshot;
     export type DocumentReference = adminFirestore.DocumentReference;
+    export type Timestamp = adminFirestore.Timestamp;
   }
 }


### PR DESCRIPTION
ひとまず現状の削除機能だけ対応
削除済み本一覧・削除した本の復旧などは追々やるということで。



---

メモ

- トランザクションが結構増えてきて、いい加減Repositoryがドメイン持ちすぎ問題がキツいのでなんとかしたい気分がある
- そろそろFirestoreのユニットテストないとそういうリファクタ出来ないなあという気持ちが芽生えてきた
- DeletedBook,Book,BookList間の依存がある状態で結構複雑になってきたという点でもUTほしげ
- `shared/` にlintとか一切入れてないのアレだと気付いた